### PR TITLE
Parse msgs from payload more efficiently

### DIFF
--- a/src/dogstatsdreplay.rs
+++ b/src/dogstatsdreplay.rs
@@ -29,9 +29,9 @@ impl DogStatsDReplay {
             Some(mut end_idx) => {
                 // Save current start of line
                 let start_idx = self.current_messages_start_idx;
-                // Set next start of line to be one after the newline char
                 end_idx += start_idx;
-                self.current_messages_start_idx = end_idx + 2;
+                // Set next start of line to be one after the newline char
+                self.current_messages_start_idx = end_idx + 1;
                 Some(&self.current_messages[start_idx..end_idx])
             }
             None => None,

--- a/src/dogstatsdreplay.rs
+++ b/src/dogstatsdreplay.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use bytes::{Buf, Bytes};
 
 extern crate zstd;
@@ -18,14 +16,31 @@ pub mod dogstatsd {
 
 pub struct DogStatsDReplay {
     buf: Bytes,
-    current_messages: VecDeque<String>,
+    current_messages: String,
+    current_messages_start_idx: usize,
 }
 
 impl DogStatsDReplay {
-    // TODO this currently returns an entire dogstatsd replay payload, which is not a single dogstatsd message.
+    pub fn next_line_in_current_messages(&mut self) -> Option<&str> {
+        if self.current_messages_start_idx >= self.current_messages.len() {
+            return None;
+        }
+        match self.current_messages[self.current_messages_start_idx..].find("\n") {
+            Some(mut end_idx) => {
+                // Save current start of line
+                let start_idx = self.current_messages_start_idx;
+                // Set next start of line to be one after the newline char
+                end_idx += start_idx;
+                self.current_messages_start_idx = end_idx + 2;
+                Some(&self.current_messages[start_idx..end_idx])
+            }
+            None => None,
+        }
+    }
+
     pub fn read_msg(&mut self, s: &mut String) -> std::io::Result<usize> {
-        if let Some(line) = self.current_messages.pop_front() {
-            s.insert_str(0, &line);
+        if let Some(line) = self.next_line_in_current_messages() {
+            s.insert_str(0, line);
             return Ok(1);
         }
 
@@ -53,13 +68,11 @@ impl DogStatsDReplay {
 
                 // should already be empty
                 self.current_messages.clear();
-                for line in v.lines() {
-                    self.current_messages.push_back(String::from(line));
-                }
+                self.current_messages_start_idx = 0;
+                self.current_messages.insert_str(0, v);
 
                 let line = self
-                    .current_messages
-                    .pop_front()
+                    .next_line_in_current_messages()
                     .expect("Found no next line, why not?? ");
 
                 s.insert_str(0, &line);
@@ -74,7 +87,8 @@ impl DogStatsDReplay {
 
         DogStatsDReplay {
             buf,
-            current_messages: VecDeque::new(),
+            current_messages: String::new(),
+            current_messages_start_idx: 0,
         }
     }
 }


### PR DESCRIPTION
# MacOS
From `main`:
```
replay parsing -- more msgs and more lines                                                                            
                        time:   [366.54 ns 368.89 ns 371.61 ns]
```
From this branch:
```
replay parsing -- more msgs and more lines                                                                            
                        time:   [291.85 ns 292.92 ns 293.98 ns]
```

# Linux VM on macos

From `main`:
```
replay parsing -- more msgs and more lines
                        time:   [204.27 ns 204.73 ns 205.26 ns]
```

From this branch:
```
replay parsing -- more msgs and more lines
                        time:   [293.24 ns 293.56 ns 293.89 ns]
```

# Linux x64 VM on ec2
From `main`:
```
replay parsing -- more msgs and more lines
                        time:   [264.38 ns 264.48 ns 264.60 ns]
```
From this branch:
```
replay parsing -- more msgs and more lines
                        time:   [441.76 ns 441.93 ns 442.10 ns]
```

**Note these two linux results, significantly worse than main!**