### PR TITLE
Smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,6 +508,7 @@ dependencies = [
  "prost-build",
  "rand",
  "regex",
+ "smallvec 2.0.0-alpha.1",
  "thiserror",
  "tokio",
  "tracing",
@@ -1148,7 +1149,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.11.2",
  "windows-targets 0.48.5",
 ]
 
@@ -1599,9 +1600,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
+name = "smallvec"
+version = "2.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af12b8880f45a593fc99ac6d0a066f762861ea6822a6a6790fa1363d70a8089"
 
 [[package]]
 name = "socket2"
@@ -1981,7 +1988,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.11.2",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?branch=main#8a8f84452737e9ab3cc1f5fda2c021b2fa89ac02"
+source = "git+https://github.com/DataDog/lading.git?branch=main#6e26fc9edef3574c8dc6b9ddb13852f45ea0c2bf"
 dependencies = [
  "bytes",
  "opentelemetry-proto",
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "lading-throttle"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?branch=main#8a8f84452737e9ab3cc1f5fda2c021b2fa89ac02"
+source = "git+https://github.com/DataDog/lading.git?branch=main#6e26fc9edef3574c8dc6b9ddb13852f45ea0c2bf"
 dependencies = [
  "async-trait",
  "metrics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = "1.4.0"
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"]  }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "tracing-log", "std", "env-filter", "json"] }
 divan = "0.1.5"
+smallvec = "2.0.0-alpha.1"
 
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ harness = false
 name = "dogstatsdmsg"
 harness = false
 
+[[bench]]
+name = "analysis"
+harness = false
+
 [profile.release-with-debug]
 inherits = "release"
 debug = true

--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use bytes::Bytes;
+use divan::counter::BytesCount;
+use dogstatsd_utils::{
+    analysis::analyze_msgs, dogstatsdmsg::DogStatsDStr, dogstatsdreader::DogStatsDReader,
+};
+use lading_payload::dogstatsd::{self, KindWeights, MetricWeights, ValueConf};
+use rand::{rngs::SmallRng, SeedableRng};
+
+fn main() {
+    // Run registered benchmarks.
+    divan::main();
+}
+
+#[divan::bench(min_time = Duration::from_secs(10))]
+fn analysis_throughput(bencher: divan::Bencher) {
+    let mut rng = SmallRng::seed_from_u64(34512423); // todo use random seed
+    let dd = dogstatsd::DogStatsD::new(
+        // Contexts
+        dogstatsd::ConfRange::Inclusive {
+            min: 500,
+            max: 10000,
+        },
+        // Service check name length
+        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        // name length
+        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        // tag_key_length
+        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        // tag_value_length
+        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        // tags_per_msg
+        dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
+        // multivalue_count
+        dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
+        // multivalue_pack_probability
+        0.08,
+        KindWeights::default(),
+        MetricWeights::default(),
+        ValueConf::default(),
+        &mut rng,
+    )
+    .expect("Failed to create dogstatsd generator");
+
+    bencher
+        .with_inputs(|| {
+            let payload = format!("{}", dd.generate(&mut rng)).into_bytes();
+            (payload.len(), DogStatsDReader::new(Bytes::from(payload)))
+        })
+        .input_counter(|(len, _)| {
+            // Changes based on input.
+            BytesCount::usize(*len)
+        })
+        .bench_local_values(|(_, mut reader)| {
+            analyze_msgs(&mut reader).unwrap();
+        })
+}

--- a/benches/analysis.rs
+++ b/benches/analysis.rs
@@ -36,6 +36,10 @@ fn analysis_throughput(bencher: divan::Bencher) {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         KindWeights::default(),
         MetricWeights::default(),
         ValueConf::default(),

--- a/benches/dogstatsdmsg.rs
+++ b/benches/dogstatsdmsg.rs
@@ -45,6 +45,10 @@ fn dogstatsdmsg_parsing_throughput(bencher: divan::Bencher) {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         KindWeights::default(),
         MetricWeights::default(),
         ValueConf::default(),
@@ -88,6 +92,10 @@ fn dogstatsdmsg_parsing_metrics_only_throughput(bencher: divan::Bencher) {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         kind_weights,
         MetricWeights::default(),
         ValueConf::default(),
@@ -131,6 +139,10 @@ fn dogstatsdmsg_parsing_events_only_throughput(bencher: divan::Bencher) {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         kind_weights,
         MetricWeights::default(),
         ValueConf::default(),
@@ -174,6 +186,10 @@ fn dogstatsdmsg_parsing_servicechecks_only_throughput(bencher: divan::Bencher) {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         kind_weights,
         MetricWeights::default(),
         ValueConf::default(),

--- a/src/bin/dsd-generate.rs
+++ b/src/bin/dsd-generate.rs
@@ -135,6 +135,10 @@ async fn main() -> Result<(), DSDGenerateError> {
         dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
         // multivalue_pack_probability
         0.08,
+        // sample_rate_range
+        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        // sample_rate_choose_probability
+        0.50,
         KindWeights::default(),
         metric_weights,
         ValueConf::default(),

--- a/src/dogstatsdmsg.rs
+++ b/src/dogstatsdmsg.rs
@@ -48,7 +48,7 @@ pub struct DogStatsDEventStr<'a> {
     pub alert_type: Option<&'a str>, // Set to error, warning, info, or success. Default info.
     pub aggregation_key: Option<&'a str>,
     pub source_type_name: Option<&'a str>,
-    pub tags: Vec<&'a str>,
+    pub tags: SmallVec<&'a str, MAX_TAGS>,
     pub raw_msg: &'a str,
 }
 
@@ -199,7 +199,7 @@ impl<'a> DogStatsDStr<'a> {
         let mut alert_type = None;
         let mut aggregation_key = None;
         let mut source_type_name = None;
-        let mut tags = Vec::new();
+        let mut tags = smallvec![];
 
         let post_text_idx = end_lengths_idx + 2 + title_length + text_length + 1;
         if post_text_idx < str_msg.len() {
@@ -422,7 +422,8 @@ mod tests {
                 assert_eq!(msg.hostname, $expected_hostname);
                 assert_eq!(msg.priority, $expected_priority);
                 assert_eq!(msg.alert_type, $expected_alert_type);
-                assert_eq!(msg.tags, $expected_tags);
+                let expected_tags: SmallVec<&str, MAX_TAGS> = $expected_tags;
+                assert_eq!(msg.tags, expected_tags);
             }
         };
     }
@@ -657,7 +658,7 @@ mod tests {
         None,
         None,
         None,
-        Vec::<&str>::new(),
+        smallvec![],
         None::<DogStatsDMsgError>
     );
 
@@ -670,7 +671,7 @@ mod tests {
         None,
         None,
         None,
-        Vec::<&str>::new(),
+        smallvec![],
         None::<DogStatsDMsgError>
     );
 
@@ -683,7 +684,7 @@ mod tests {
         None,
         None,
         None,
-        Vec::<&str>::new(),
+        smallvec![],
         None::<DogStatsDMsgError> // This is arguably invalid, but don't care at the moment
     );
 
@@ -696,7 +697,7 @@ mod tests {
         Some("myhost"),
         Some("high"),
         Some("severe"),
-        vec!["env:prod", "onfire:true"],
+        smallvec!["env:prod", "onfire:true"],
         None::<DogStatsDMsgError>
     );
 
@@ -709,7 +710,7 @@ mod tests {
         None,
         None,
         None,
-        Vec::<&str>::new(),
+        smallvec![],
         Some(DogStatsDMsgError::InvalidEvent)
     );
 


### PR DESCRIPTION
According to `divan`, not as much improvement on the low-end as I would have expected, but a good boost on the `mean and `median`

## `Main`:
```
# run 1
Timer precision: 41 ns
dogstatsdmsg                                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ dogstatsdmsg_parsing_metrics_only_throughput  181.9 ns      │ 90.44 µs      │ 312.1 ns      │ 312.4 ns      │ 1420812 │ 11366496
                                                 335.3 MB/s    │ 1.57 MB/s     │ 429.2 MB/s    │ 387.2 MB/s    │         │

# run 2
Timer precision: 41 ns
dogstatsdmsg                                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ dogstatsdmsg_parsing_metrics_only_throughput  205.4 ns      │ 281.4 µs      │ 314.7 ns      │ 316.6 ns      │ 705169  │ 11282704
                                                 355.3 MB/s    │ 362.3 KB/s    │ 359 MB/s      │ 382.1 MB/s    │         │
```

## `smallvec`
```
# run 1
Timer precision: 41 ns
dogstatsdmsg                                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ dogstatsdmsg_parsing_metrics_only_throughput  210.6 ns      │ 75.69 µs      │ 291.3 ns      │ 293.7 ns      │ 714373  │ 11429968
                                                 375.1 MB/s    │ 1.704 MB/s    │ 453 MB/s      │ 411.9 MB/s    │         │
# run 2
Timer precision: 41 ns
dogstatsdmsg                                     fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ dogstatsdmsg_parsing_metrics_only_throughput  210.6 ns      │ 350.8 µs      │ 288.7 ns      │ 291.9 ns      │ 731812  │ 11708992
                                                 346.6 MB/s    │ 316.3 KB/s    │ 436.3 MB/s    │ 414.4 MB/s    │         │
```