### PR TITLE
Add ability to generate lading config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,6 @@ dependencies = [
  "clap 4.4.4",
  "criterion",
  "divan",
- "histo",
  "indicatif",
  "lading-payload",
  "lading-throttle",
@@ -531,6 +530,7 @@ dependencies = [
  "rand",
  "regex",
  "serde_yaml",
+ "sketches-ddsketch",
  "smallvec 2.0.0-alpha.1",
  "thiserror",
  "tokio",
@@ -757,15 +757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "histo"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a96a1c8acf372eefef3b065d800986a6d11abdc2c27cc61255513646b3df6c"
-dependencies = [
- "streaming-stats",
 ]
 
 [[package]]
@@ -1749,6 +1740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,15 +1784,6 @@ checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "streaming-stats"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc32bf233385fb1ae0c4cf13a8dfd11efec71f6a9de95feac8c870788bc8b25"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +294,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +382,12 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "criterion"
@@ -514,9 +549,11 @@ dependencies = [
  "byte-unit",
  "byteorder",
  "bytes",
+ "chrono",
  "clap 4.4.4",
  "criterion",
  "divan",
+ "human_bytes",
  "indicatif",
  "lading-payload",
  "lading-throttle",
@@ -803,6 +840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_bytes"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +879,29 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2333,6 +2399,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2456,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2481,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2405,6 +2501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +2517,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2429,6 +2537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2553,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2453,6 +2573,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +2589,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "async-io"
@@ -347,6 +347,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cgroups-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db7c2f5545da4c12c5701455d9471da5f07db52e49b9cccb4f5512226dd0836"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "regex",
+ "thiserror",
+]
 
 [[package]]
 name = "chrono"
@@ -689,6 +702,8 @@ dependencies = [
  "prost-build 0.11.9",
  "rand",
  "regex",
+ "serde",
+ "serde_json",
  "serde_yaml",
  "sketches-ddsketch",
  "smallvec 2.0.0-alpha.1",
@@ -1250,13 +1265,14 @@ dependencies = [
 
 [[package]]
 name = "lading"
-version = "0.20.6"
-source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+version = "0.20.8"
+source = "git+https://github.com/DataDog/lading.git?rev=cd7bd9d477707d375b2f841e361587af48d30e88#cd7bd9d477707d375b2f841e361587af48d30e88"
 dependencies = [
  "async-pidfd",
  "average",
  "byte-unit",
  "bytes",
+ "cgroups-rs",
  "clap 3.2.25",
  "flate2",
  "futures",
@@ -1270,7 +1286,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
- "nix",
+ "nix 0.27.1",
  "num_cpus",
  "once_cell",
  "procfs",
@@ -1295,7 +1311,7 @@ dependencies = [
 [[package]]
 name = "lading-capture"
 version = "0.1.1"
-source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+source = "git+https://github.com/DataDog/lading.git?rev=cd7bd9d477707d375b2f841e361587af48d30e88#cd7bd9d477707d375b2f841e361587af48d30e88"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.12.3",
@@ -1308,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+source = "git+https://github.com/DataDog/lading.git?rev=cd7bd9d477707d375b2f841e361587af48d30e88#cd7bd9d477707d375b2f841e361587af48d30e88"
 dependencies = [
  "bytes",
  "opentelemetry-proto",
@@ -1328,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "lading-throttle"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+source = "git+https://github.com/DataDog/lading.git?rev=cd7bd9d477707d375b2f841e361587af48d30e88#cd7bd9d477707d375b2f841e361587af48d30e88"
 dependencies = [
  "async-trait",
  "metrics",
@@ -1530,6 +1546,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec 1.11.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -321,7 +321,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -504,7 +504,7 @@ checksum = "875fb84b58aa0b32af7a1c768083693c01b7625571b1a46c40f3c8b42ce58b1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -530,6 +530,7 @@ dependencies = [
  "prost-build",
  "rand",
  "regex",
+ "serde_yaml",
  "smallvec 2.0.0-alpha.1",
  "thiserror",
  "tokio",
@@ -650,7 +651,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -739,9 +740,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -858,12 +859,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1036,7 +1037,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1226,7 +1227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -1246,7 +1247,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1340,7 +1341,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1410,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -1473,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1665,9 +1666,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
@@ -1684,20 +1685,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1723,6 +1724,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
+dependencies = [
+ "indexmap 2.2.2",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1803,9 +1817,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1867,7 +1881,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1952,7 +1966,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2077,7 +2091,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2169,6 +2183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,7 +2258,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2260,7 +2280,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite",
+ "log",
+ "parking",
+ "polling",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.9",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-pidfd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12177058299bb8e3507695941b6d0d7dc0e4e6515b8bc1bf4609d9e32ef51799"
+dependencies = [
+ "async-io",
+ "libc",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +184,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -155,6 +194,16 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "average"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d804c74bb2d66e9b7047658d21af0f1c937d7d2466410cbf1aed3b0c04048d4"
+dependencies = [
+ "float-ord",
+ "num-traits",
+]
 
 [[package]]
 name = "axum"
@@ -221,6 +270,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -314,8 +369,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags 1.3.2",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_derive 3.2.25",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.3",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -325,7 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
 dependencies = [
  "clap_builder",
- "clap_derive",
+ "clap_derive 4.4.2",
 ]
 
 [[package]]
@@ -336,9 +408,22 @@ checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.5.1",
  "strsim",
  "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -355,6 +440,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
@@ -364,6 +458,15 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "condtype"
@@ -384,10 +487,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -555,6 +677,7 @@ dependencies = [
  "divan",
  "human_bytes",
  "indicatif",
+ "lading",
  "lading-payload",
  "lading-throttle",
  "lazy_static",
@@ -562,8 +685,8 @@ dependencies = [
  "new_mime_guess",
  "pcap-file",
  "pnet",
- "prost",
- "prost-build",
+ "prost 0.11.9",
+ "prost-build 0.11.9",
  "rand",
  "regex",
  "serde_yaml",
@@ -587,6 +710,21 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -616,6 +754,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,10 +781,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-ord"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -641,6 +819,7 @@ checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -679,6 +858,21 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -777,6 +971,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
@@ -795,6 +998,18 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -825,6 +1040,16 @@ dependencies = [
  "bytes",
  "http",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-serde"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f560b665ad9f1572cfcaf034f7fb84338a7ce945216d64a90fd81f046a3caee"
+dependencies = [
+ "http",
+ "serde",
 ]
 
 [[package]]
@@ -905,6 +1130,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,12 +1172,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.5",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -979,13 +1249,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "lading"
+version = "0.20.6"
+source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+dependencies = [
+ "async-pidfd",
+ "average",
+ "byte-unit",
+ "bytes",
+ "clap 3.2.25",
+ "flate2",
+ "futures",
+ "http",
+ "http-serde",
+ "hyper",
+ "is_executable",
+ "lading-capture",
+ "lading-payload",
+ "lading-throttle",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-util",
+ "nix",
+ "num_cpus",
+ "once_cell",
+ "procfs",
+ "rand",
+ "regex",
+ "reqwest",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tonic 0.9.2",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "lading-capture"
+version = "0.1.1"
+source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
+dependencies = [
+ "prost 0.11.9",
+ "prost-build 0.12.3",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "lading-payload"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?tag=v0.20.5#68b3d375af4bf072ea0ce2c9f4683f39102916d5"
+source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
 dependencies = [
  "bytes",
  "opentelemetry-proto",
- "prost",
+ "prost 0.11.9",
  "rand",
  "rmp-serde",
  "rustc-hash",
@@ -1001,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "lading-throttle"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/lading.git?tag=v0.20.5#68b3d375af4bf072ea0ce2c9f4683f39102916d5"
+source = "git+https://github.com/DataDog/lading.git?branch=sopell/generate-serialize-impl#9716af3732fcfa36a103f1ac9baa328f981b93ad"
 dependencies = [
  "async-trait",
  "metrics",
@@ -1025,6 +1352,18 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
@@ -1044,6 +1383,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "matchers"
@@ -1087,6 +1435,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+dependencies = [
+ "base64 0.21.7",
+ "hyper",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "metrics-macros"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1460,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "indexmap 1.9.3",
+ "metrics",
+ "num_cpus",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "sketches-ddsketch",
 ]
 
 [[package]]
@@ -1140,10 +1524,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec 1.11.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -1152,6 +1566,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.5",
+ "libc",
 ]
 
 [[package]]
@@ -1200,8 +1624,8 @@ dependencies = [
  "futures",
  "futures-util",
  "opentelemetry",
- "prost",
- "tonic",
+ "prost 0.11.9",
+ "tonic 0.8.3",
  "tonic-build",
 ]
 
@@ -1240,6 +1664,33 @@ dependencies = [
  "rand",
  "thiserror",
 ]
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot_core"
@@ -1445,6 +1896,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1934,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,13 +1977,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "rustix 0.36.17",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -1498,11 +2022,33 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.16",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "regex",
+ "syn 2.0.48",
  "tempfile",
  "which",
 ]
@@ -1521,12 +2067,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost 0.12.3",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1536,6 +2120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]
@@ -1569,6 +2163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "rayon"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,14 +2202,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1620,13 +2223,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -1643,9 +2246,45 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rmp"
@@ -1683,6 +2322,34 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
+version = "0.36.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
@@ -1690,7 +2357,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.7",
  "windows-sys 0.48.0",
 ]
 
@@ -1763,6 +2430,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_tuple"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +2459,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1803,6 +2493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1887,16 +2586,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall",
- "rustix",
+ "rustix 0.38.14",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1905,7 +2634,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix",
+ "rustix 0.38.14",
  "windows-sys 0.48.0",
 ]
 
@@ -1917,6 +2646,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1987,6 +2722,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,7 +2746,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -2057,7 +2809,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2068,8 +2820,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2081,14 +2833,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -2196,6 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",
@@ -2225,10 +3006,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2243,6 +3039,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8-width"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +3062,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,6 +3082,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "walkdir"
@@ -2317,6 +3140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,7 +3199,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.14",
 ]
 
 [[package]]
@@ -2595,6 +3430,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,16 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["s
 divan = "0.1.5"
 smallvec = "2.0.0-alpha.1"
 pcap-file = "2.0.0-rc1"
-lading-payload = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
-lading-throttle = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
-lading = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
+lading-payload = { git = "https://github.com/DataDog/lading.git", rev = "cd7bd9d477707d375b2f841e361587af48d30e88" }
+lading-throttle = { git = "https://github.com/DataDog/lading.git", rev = "cd7bd9d477707d375b2f841e361587af48d30e88" }
+lading = { git = "https://github.com/DataDog/lading.git", rev = "cd7bd9d477707d375b2f841e361587af48d30e88"  }
 pnet = "0.34.0"
+serde = { version = "*", features = ["derive"]}
 serde_yaml = "0.9.31"
 sketches-ddsketch = "0.2.2"
 chrono = "0.4.33"
 human_bytes = "0.4.3"
+serde_json = "1.0.113"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ bytes = "1.0.1"
 indicatif = "0.16.0"
 clap = { version = "4.3.23", features = ["derive"] }
 thiserror = "1.0"
-histo = "1.0.0"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng", "std", "std_rng" ]}
 tokio = { version = "1.32", features = ["time"] }
 byte-unit = "4.0"
@@ -29,6 +28,7 @@ lading-payload = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5
 lading-throttle = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5" }
 pnet = "0.34.0"
 serde_yaml = "0.9.31"
+sketches-ddsketch = "0.2.2"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ lading-throttle = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.
 pnet = "0.34.0"
 serde_yaml = "0.9.31"
 sketches-ddsketch = "0.2.2"
+chrono = "0.4.33"
+human_bytes = "0.4.3"
 
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,16 @@ thiserror = "1.0"
 rand = { version = "0.8.5", default-features = false, features = ["small_rng", "std", "std_rng" ]}
 tokio = { version = "1.32", features = ["time"] }
 byte-unit = "4.0"
-regex = "1.9.5"
+regex = "1.10.3"
 lazy_static = "1.4.0"
 tracing = { version = "0.1", default-features = false, features = ["std", "attributes"]  }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "tracing-log", "std", "env-filter", "json"] }
 divan = "0.1.5"
 smallvec = "2.0.0-alpha.1"
 pcap-file = "2.0.0-rc1"
-lading-payload = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5" }
-lading-throttle = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5" }
+lading-payload = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
+lading-throttle = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
+lading = { git = "https://github.com/DataDog/lading.git", branch = "sopell/generate-serialize-impl" }
 pnet = "0.34.0"
 serde_yaml = "0.9.31"
 sketches-ddsketch = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ pcap-file = "2.0.0-rc1"
 lading-payload = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5" }
 lading-throttle = { git = "https://github.com/DataDog/lading.git", tag = "v0.20.5" }
 pnet = "0.34.0"
+serde_yaml = "0.9.31"
 
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ Options:
 
 This tool takes in a stream of text dogstatsd messages either from a file or
 from stdin. These can be zstd encoded, replay files, or utf-8 encoded text.
-Prints out some basic histograms about the messages (metric name length, # of tags, etc)
+
+Analysis covers:
+- "Reader" -- how many packets were there, how big was each one, how many bytes-per-second, etc.
+- "Message" -- How many messages were metrics vs service checks, how many tags were there per metric, etc.
 
 ```
 $ dsd-analyze --help
@@ -44,9 +47,11 @@ Arguments:
   [INPUT]  File containing dogstatsd data
 
 Options:
+  -l, --lading-config  Emit lading DSD config
   -h, --help     Print help
   -V, --version  Print version
 ```
+
 
 ## `dsd-generate`
 > Install via `cargo install --git https://github.com/scottopell/dogstatsd-utils --bin dsd-generate`

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use histo::Histogram;
+use lading_payload::dogstatsd::ValueConf;
 
 use crate::{
     dogstatsdmsg::{DogStatsDMetricType, DogStatsDMsg, DogStatsDMsgKind},
@@ -13,14 +14,116 @@ use crate::{
 
 const DEFAULT_NUM_BUCKETS: u64 = 10;
 
+pub fn histo_min_max(histo: &histo::Histogram) -> (u64, u64) {
+    let min = histo.buckets().filter(|bucket| bucket.count() > 0).map(|bucket| bucket.start()).min().unwrap_or_default();
+    let max = histo.buckets().filter(|bucket| bucket.count() > 0).map(|bucket| bucket.end()).max().unwrap_or_default();
+    (min, max)
+}
+
+fn get_metric_weights(batch: &DogStatsDBatchStats) -> lading_payload::dogstatsd::MetricWeights {
+    // metric weights
+    let metric_map = match batch.kind.get(&DogStatsDMsgKind::Metric) {
+        Some((_, Some(m))) => m,
+        _ => return lading_payload::dogstatsd::MetricWeights::default(),
+    };
+
+    let num_count = *metric_map.get(&DogStatsDMetricType::Count).unwrap_or(&0);
+    let num_gauge = *metric_map.get(&DogStatsDMetricType::Gauge).unwrap_or(&0);
+    let num_set = *metric_map.get(&DogStatsDMetricType::Set).unwrap_or(&0);
+    let num_timer = *metric_map.get(&DogStatsDMetricType::Timer).unwrap_or(&0);
+    let num_histogram = *metric_map.get(&DogStatsDMetricType::Histogram).unwrap_or(&0);
+    let num_distribution = *metric_map.get(&DogStatsDMetricType::Distribution).unwrap_or(&0);
+
+    let scale_factor = (num_count + num_gauge + num_set + num_timer + num_histogram + num_distribution) as f32 / u8::MAX as f32;
+    let num_count = (num_count as f32 / scale_factor).round() as u8;
+    let num_gauge = (num_gauge as f32 / scale_factor).round() as u8;
+    let num_set = (num_set as f32 / scale_factor).round() as u8;
+    let num_timer = (num_timer as f32 / scale_factor).round() as u8;
+    let num_histogram = (num_histogram as f32 / scale_factor).round() as u8;
+    let num_distribution = (num_distribution as f32 / scale_factor).round() as u8;
+
+    lading_payload::dogstatsd::MetricWeights::new(num_count, num_gauge, num_set, num_timer, num_histogram, num_distribution)
+}
+
+type KindCount = (u32, Option<HashMap<DogStatsDMetricType, u32>>);
+type KindMap = HashMap<DogStatsDMsgKind, KindCount>;
+
 pub struct DogStatsDBatchStats {
     pub name_length: Histogram,
     pub num_values: Histogram,
     pub num_tags: Histogram,
+    pub tag_total_length: Histogram,
     pub num_unicode_tags: Histogram,
-    pub kind: HashMap<DogStatsDMsgKind, (u32, Option<HashMap<DogStatsDMetricType, u32>>)>,
+    pub kind: KindMap,
     pub num_contexts: u32,
     pub total_unique_tags: u32,
+}
+
+impl DogStatsDBatchStats {
+    pub fn to_lading_config(&self) -> lading_payload::dogstatsd::Config {
+        let (min, max) = histo_min_max(&self.name_length);
+        let num_contexts = lading_payload::dogstatsd::ConfRange::Constant(self.num_contexts);
+        let name_length = lading_payload::dogstatsd::ConfRange::Inclusive{ min: min as u16, max: max as u16 };
+
+        let (min, max) = histo_min_max(&self.tag_total_length);
+        let tag_key_length = lading_payload::dogstatsd::ConfRange::Inclusive{min: min as u8, max: max as u8};
+        let tag_value_length = lading_payload::dogstatsd::ConfRange::Inclusive{min: min as u8, max: max as u8};
+
+        // num_values is non-zero when there is more than one value present
+        // so to calculate the multivalue-pack-probability, its just the number of
+        // non-zero values divided by the total number of values
+        let mut zero_count = 0;
+        let mut non_zero_count = 0;
+        for bucket in self.num_values.buckets() {
+            if bucket.start() == 0 && bucket.end() > 0 {
+                zero_count = bucket.count();
+            } else {
+                non_zero_count += bucket.count();
+            }
+        }
+        let multivalue_pack_probability = non_zero_count as f32 / (zero_count + non_zero_count) as f32;
+
+        // kind weights
+        let num_metrics = match self.kind.get(&DogStatsDMsgKind::Metric) {
+            Some((v, _)) => *v,
+            None => 0,
+        };
+        let num_events = match self.kind.get(&DogStatsDMsgKind::Event) {
+            Some((v, _)) => *v,
+            None => 0,
+        };
+        let num_service_checks = match self.kind.get(&DogStatsDMsgKind::ServiceCheck) {
+            Some((v, _)) => *v,
+            None => 0,
+        };
+
+        let scale_factor = (num_metrics + num_events + num_service_checks) as f32 / u8::MAX as f32;
+
+        let num_metrics = (num_metrics as f32 / scale_factor).round() as u8;
+        let num_events = (num_events as f32 / scale_factor).round() as u8;
+        let num_service_checks = (num_service_checks as f32 / scale_factor).round() as u8;
+
+        let kind_weights = lading_payload::dogstatsd::KindWeights::new(num_metrics, num_events, num_service_checks);
+
+        let metric_weights = get_metric_weights(self);
+
+        lading_payload::dogstatsd::Config {
+            contexts: num_contexts,
+            kind_weights,
+            service_check_names: lading_payload::dogstatsd::ConfRange::Constant(0),// todo
+            name_length,
+            tag_key_length,
+            tag_value_length,
+            tags_per_msg: lading_payload::dogstatsd::ConfRange::Constant(0),// todo
+            multivalue_pack_probability,
+            multivalue_count: lading_payload::dogstatsd::ConfRange::Constant(0),// todo
+            length_prefix_framed: false,
+            sampling_range: lading_payload::dogstatsd::ConfRange::Constant(0.0),// todo
+            sampling_probability: 0.0, // todo
+            metric_weights,
+            value: ValueConf::default(),
+        }
+    }
 }
 
 pub fn print_msgs<T>(reader: &mut DogStatsDReader, mut out: T)
@@ -39,6 +142,7 @@ where
     }
 }
 
+
 pub fn analyze_msgs(
     reader: &mut DogStatsDReader,
 ) -> Result<DogStatsDBatchStats, std::io::Error>
@@ -48,6 +152,7 @@ pub fn analyze_msgs(
         name_length: Histogram::with_buckets(default_num_buckets),
         num_values: Histogram::with_buckets(default_num_buckets),
         num_tags: Histogram::with_buckets(default_num_buckets),
+        tag_total_length: Histogram::with_buckets(default_num_buckets),
         num_unicode_tags: Histogram::with_buckets(default_num_buckets),
         kind: HashMap::new(),
         total_unique_tags: 0,
@@ -109,6 +214,7 @@ pub fn analyze_msgs(
         let mut num_unicode_tags = 0;
         let num_tags = metric_msg.tags.len() as u64;
         for tag in &metric_msg.tags {
+            msg_stats.tag_total_length.add(tag.len() as u64);
             tags_seen.insert(tag.to_string());
             if !tag.is_ascii() {
                 num_unicode_tags += 1;
@@ -258,4 +364,32 @@ mod tests {
         // 6 because of the empty tags
         assert_eq!(res.num_contexts, 6);
     }
+
+    #[test]
+    fn batch_stats_to_lading_config() {
+        let mut stats = DogStatsDBatchStats {
+            name_length: Histogram::with_buckets(10),
+            num_tags: Histogram::with_buckets(10),
+            tag_total_length: Histogram::with_buckets(10),
+            num_unicode_tags: Histogram::with_buckets(10),
+            kind: HashMap::new(),
+            total_unique_tags: 0,
+            num_contexts: 0,
+            num_values: Histogram::with_buckets(10),
+        };
+
+        stats.name_length.add(10);
+        stats.name_length.add(10);
+        stats.name_length.add(10);
+        stats.name_length.add(10);
+
+        let lading_config = stats.to_lading_config();
+        // This currently fails because the bucket range is 10-11, so the max is 11
+        // even though there are no samples at this value.
+        // This strikes me as an indication that I have outgrown the histo::histogram crate
+        // lets try dd-sketch
+        assert_eq!(lading_config.name_length, lading_payload::dogstatsd::ConfRange::Inclusive{min: 10, max: 10});
+    }
+
+
 }

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -28,6 +28,7 @@ pub struct DogStatsDBatchStats {
     pub total_unique_tags: u32,
     pub num_msgs_with_multivalue: u32,
     pub num_msgs: u32,
+    pub reader_analytics: Option<crate::dogstatsdreader::Analytics>,
 }
 
 #[derive(Error, Debug)]
@@ -192,6 +193,7 @@ pub fn analyze_msgs(
         num_contexts: 0,
         num_msgs: 0,
         num_msgs_with_multivalue: 0,
+        reader_analytics: None,
     };
 
     let mut metric_type_map = HashMap::new();
@@ -295,6 +297,8 @@ pub fn analyze_msgs(
             });
     }
 
+    // Have read through the entire reader, lets try to grab the final "Analytics" if it exists
+    msg_stats.reader_analytics = reader.get_analytics().expect("Error getting analytics from reader");
     msg_stats.total_unique_tags = tags_seen.len() as u32;
     msg_stats.num_contexts = context_map.len() as u32;
     Ok(msg_stats)

--- a/src/bin/dsd-analyze.rs
+++ b/src/bin/dsd-analyze.rs
@@ -21,6 +21,8 @@ pub enum AnalyzeError {
     Io(#[from] io::Error),
     #[error("Serde Error")]
     Serde(#[from] serde_yaml::Error),
+    #[error("Serde Error json")]
+    SerdeJSON(#[from] serde_json::Error),
 }
 
 /// Analyze DogStatsD traffic messages
@@ -31,7 +33,7 @@ struct Args {
     input: Option<String>,
 
     /// Emit lading DSD config
-    #[arg(long, short, default_value_t = true)]
+    #[arg(long, short, default_value_t = false)]
     lading_config: bool,
 }
 
@@ -72,38 +74,11 @@ fn main() -> Result<(), AnalyzeError> {
     }?;
 
     let msg_stats = analyze_msgs(&mut reader)?;
-
-    println!("Total Messages:\n\t{}", msg_stats.num_msgs);
-    println!("Name Length:\n{}", sketch_to_string(&msg_stats.name_length));
-    println!("# values per msg:\n{}", sketch_to_string(&msg_stats.num_values));
-    println!("# tags per msg:\n{}", sketch_to_string(&msg_stats.num_tags));
-    println!("# unicode tags per msg:\n{}", sketch_to_string(&msg_stats.num_unicode_tags));
-    println!("# of Unique Tags:\n\t{}", msg_stats.total_unique_tags);
-    println!("# of Contexts:\n\t{}", msg_stats.num_contexts);
-    println!();
-    println!("Metric Kind Breakdown:");
-    for (kind, (cnt, per_type)) in msg_stats.kind.iter() {
-        if let Some(per_type) = per_type {
-            println!("\t{} Total {}", kind, cnt);
-            for (t, cnt) in per_type.iter() {
-                println!("\t\t{}: {}", t, cnt);
-            }
-        } else {
-            println!("\t{}: {}", kind, cnt);
-        }
-    }
-    println!();
-
-    if args.lading_config {
-        let lading_config = msg_stats.to_lading_config().expect("Error converting to lading config");
-        let str_lading_config = serde_yaml::to_string(&lading_config)?;
-        println!("Lading Config:\n---\n{}---", str_lading_config);
-    }
-
-    if let Some(reader_analytics) = msg_stats.reader_analytics {
+    if let Some(ref reader_analytics) = msg_stats.reader_analytics {
         println!("Reader Analytics:");
         let first_timestamp = epoch_duration_to_datetime(reader_analytics.earliest_timestamp);
         let last_timestamp = epoch_duration_to_datetime(reader_analytics.latest_timestamp);
+        println!("\tTransport: {}", reader_analytics.transport_type);
         println!("\tFirst packet time: {}", first_timestamp.to_rfc3339());
         println!("\tLast packet time: {}", last_timestamp.to_rfc3339());
         println!("\tDuration: {:?}", reader_analytics.duration());
@@ -112,6 +87,29 @@ fn main() -> Result<(), AnalyzeError> {
         println!("\tTotal Messages: {}", reader_analytics.total_messages);
 
         println!("\tAverage Bytes Per Second:  {} per second", human_bytes(reader_analytics.average_bytes_per_second()));
+    }
+
+    println!("Traffic Analytics:");
+    println!("Name Length:\n{}", sketch_to_string(&msg_stats.name_length));
+    println!("# values per msg:\n{}", sketch_to_string(&msg_stats.num_values));
+    println!("# tags per msg:\n{}", sketch_to_string(&msg_stats.num_tags));
+    println!("# unicode tags per msg:\n{}", sketch_to_string(&msg_stats.num_unicode_tags));
+    println!("# of Unique Tags:\n\t{}", msg_stats.total_unique_tags);
+    println!("# of Contexts:\n\t{}", msg_stats.num_contexts);
+    println!();
+    println!("Message Kind Breakdown:");
+    for (kind, (cnt, per_type)) in msg_stats.kind.iter() {
+        println!("\t{}: {}", kind, cnt);
+        if let Some(per_type) = per_type {
+            for (t, cnt) in per_type.iter() {
+                println!("\t\t{}: {}", t, cnt);
+            }
+        }
+    }
+
+    if args.lading_config {
+        let str_lading_config = msg_stats.to_lading_config_str().expect("Error converting to lading config");
+        println!("Lading Config:\n---\n{}---", str_lading_config);
     }
 
     Ok(())

--- a/src/bin/dsd-analyze.rs
+++ b/src/bin/dsd-analyze.rs
@@ -106,14 +106,12 @@ fn main() -> Result<(), AnalyzeError> {
         let last_timestamp = epoch_duration_to_datetime(reader_analytics.latest_timestamp);
         println!("\tFirst packet time: {}", first_timestamp.to_rfc3339());
         println!("\tLast packet time: {}", last_timestamp.to_rfc3339());
-        println!("\tDuration: {:?}", reader_analytics.latest_timestamp - reader_analytics.earliest_timestamp);
+        println!("\tDuration: {:?}", reader_analytics.duration());
         println!("\tTotal Packets: {}", reader_analytics.total_packets);
         println!("\tTotal Bytes: {}", human_bytes(reader_analytics.total_bytes as f64));
         println!("\tTotal Messages: {}", reader_analytics.total_messages);
 
-        let duration = reader_analytics.latest_timestamp - reader_analytics.earliest_timestamp;
-        let avg_throughput = reader_analytics.total_bytes as f64 / duration.as_secs_f64();
-        println!("\tAverage Bytes Per Second:  {} per second", human_bytes(avg_throughput));
+        println!("\tAverage Bytes Per Second:  {} per second", human_bytes(reader_analytics.average_bytes_per_second()));
     }
 
     Ok(())

--- a/src/bin/dsd-analyze.rs
+++ b/src/bin/dsd-analyze.rs
@@ -15,6 +15,8 @@ pub enum AnalyzeError {
     ReaderFailure(#[from] dogstatsd_utils::dogstatsdreader::DogStatsDReaderError),
     #[error("IO Error")]
     Io(#[from] io::Error),
+    #[error("Serde Error")]
+    Serde(#[from] serde_yaml::Error),
 }
 
 /// Analyze DogStatsD traffic messages
@@ -23,6 +25,10 @@ pub enum AnalyzeError {
 struct Args {
     /// File containing dogstatsd data
     input: Option<String>,
+
+    /// Emit lading DSD config
+    #[arg(long, short, default_value_t = false)]
+    lading_config: bool,
 }
 
 fn main() -> Result<(), AnalyzeError> {
@@ -58,6 +64,12 @@ fn main() -> Result<(), AnalyzeError> {
     println!();
     println!("# of Unique Tags: {}", msg_stats.total_unique_tags);
     println!("# of Contexts: {}", msg_stats.num_contexts);
+
+    if args.lading_config {
+        let lading_config = msg_stats.to_lading_config();
+        let str_lading_config = serde_yaml::to_string(&lading_config)?;
+        println!("Lading Config:\n{}", str_lading_config);
+    }
 
     Ok(())
 }

--- a/src/bin/dsd-cat.rs
+++ b/src/bin/dsd-cat.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::fs::File;
 use std::io::stdout;
-use std::io::Error;
 
 use std::io::{self};
 use std::path::Path;

--- a/src/bin/dsd-generate.rs
+++ b/src/bin/dsd-generate.rs
@@ -144,14 +144,14 @@ async fn main() -> Result<(), DSDGenerateError> {
 
     if let Some(num_msgs) = args.num_msgs {
         for _ in 0..num_msgs {
-            println!("{}", dd.generate(&mut rng));
+            println!("{}", dd.generate(&mut rng).unwrap());
         }
     } else if let Some(rate) = args.rate {
         match parse_rate(&rate) {
             Some(RateSpecification::TimerBased(hz_value)) => loop {
                 let sleep_in_ms = 1000 / (hz_value as u64);
                 sleep(Duration::from_millis(sleep_in_ms)).await;
-                println!("{}", dd.generate(&mut rng));
+                println!("{}", dd.generate(&mut rng).unwrap());
             },
             Some(RateSpecification::ThroughputBased(bytes_per_second)) => {
                 let mut throttle = Throttle::new_with_config(
@@ -159,7 +159,7 @@ async fn main() -> Result<(), DSDGenerateError> {
                     NonZeroU32::new(bytes_per_second).unwrap(),
                 );
                 loop {
-                    let msg = dd.generate(&mut rng);
+                    let msg = dd.generate(&mut rng).unwrap();
                     let msg_str = msg.to_string();
                     let _ = throttle
                         .wait_for(NonZeroU32::new(msg_str.len() as u32).unwrap())
@@ -172,7 +172,7 @@ async fn main() -> Result<(), DSDGenerateError> {
             }
         }
     } else {
-        println!("{}", dd.generate(&mut rng));
+        println!("{}", dd.generate(&mut rng).unwrap());
     }
 
     Ok(())

--- a/src/bin/dsd-generate.rs
+++ b/src/bin/dsd-generate.rs
@@ -113,31 +113,24 @@ async fn main() -> Result<(), DSDGenerateError> {
         None => dogstatsd::ConfRange::Inclusive { min: 100, max: 500 },
     };
     let length_prefix_framed = false;
-    let dd = dogstatsd::DogStatsD::new(
-        // Contexts
-        context_range,
-        // Service check name length
-        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
-        // name length
-        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
-        // tag_key_length
-        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
-        // tag_value_length
-        dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
-        // tags_per_msg
-        dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
-        // multivalue_count
-        dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
-        // multivalue_pack_probability
-        0.08,
-        // sample_rate_range
-        dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
-        // sample_rate_choose_probability
-        0.50,
-        KindWeights::default(),
+    let dogstatsd_config = dogstatsd::Config{
+        contexts: context_range,
+        service_check_names: dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        name_length: dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        tag_key_length: dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        tag_value_length: dogstatsd::ConfRange::Inclusive { min: 5, max: 10 },
+        tags_per_msg: dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
+        multivalue_count: dogstatsd::ConfRange::Inclusive { min: 1, max: 10 },
+        multivalue_pack_probability: 0.08,
+        sampling_range: dogstatsd::ConfRange::Inclusive { min: 0.1, max: 1.0 },
+        sampling_probability: 0.50,
+        kind_weights: KindWeights::default(),
         metric_weights,
-        ValueConf::default(),
+        value: ValueConf::default(),
         length_prefix_framed,
+    };
+    let dd = dogstatsd::DogStatsD::new(
+        dogstatsd_config,
         &mut rng,
     )
     .expect("Failed to create dogstatsd generator");

--- a/src/dogstatsdreader.rs
+++ b/src/dogstatsdreader.rs
@@ -3,14 +3,14 @@ use std::io::BufRead;
 use std::io::Read;
 use std::time::Duration;
 
-use bytes::{Bytes};
+use bytes::Bytes;
 use thiserror::Error;
 use tracing::{debug, error, info};
 
 use crate::{
     dogstatsdreplayreader::{DogStatsDReplayReader, DogStatsDReplayReaderError},
     pcapdogstatsdreader::{PcapDogStatsDReader, PcapDogStatsDReaderError},
-    replay::{ReplayReaderError},
+    replay::ReplayReaderError,
     utf8dogstatsdreader::Utf8DogStatsDReader,
     zstd::is_zstd,
 };
@@ -32,6 +32,15 @@ pub enum Transport {
     Udp,
     UnixDatagram,
     // UnixStream, not supported yet
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Transport::Udp => write!(f, "UDP"),
+            Transport::UnixDatagram => write!(f, "Unix Datagram"),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/dogstatsdreplayreader.rs
+++ b/src/dogstatsdreplayreader.rs
@@ -88,7 +88,7 @@ impl<'a> DogStatsDReplayReader<'a>
             Ok(reader) => Ok(DogStatsDReplayReader {
                 replay_msg_reader: reader,
                 current_messages: VecDeque::new(),
-                analytics: dogstatsdreader::Analytics::new(),
+                analytics: dogstatsdreader::Analytics::new(dogstatsdreader::Transport::UnixDatagram),
             }),
             Err(e) => match e {
                 ReplayReaderError::NotAReplayFile => {

--- a/src/dogstatsdreplayreader.rs
+++ b/src/dogstatsdreplayreader.rs
@@ -1,9 +1,9 @@
-use std::{collections::VecDeque, str::Utf8Error, io::{BufRead}};
+use std::{collections::VecDeque, io::BufRead, str::Utf8Error, time::Duration};
 use thiserror::Error;
 
 
 
-use crate::replay::{ReplayReader, ReplayReaderError};
+use crate::{dogstatsdreader, replay::{ReplayReader, ReplayReaderError}};
 
 pub mod dogstatsd {
     pub mod unix {
@@ -25,18 +25,41 @@ pub struct DogStatsDReplayReader<'a>
 {
     replay_msg_reader: ReplayReader<'a>,
     current_messages: VecDeque<String>,
+    analytics: dogstatsdreader::Analytics,
 }
 
 impl<'a> DogStatsDReplayReader<'a>
 {
+    pub fn get_analytics(&self) -> Result<dogstatsdreader::Analytics, DogStatsDReplayReaderError> {
+        Ok(self.analytics.clone())
+    }
     pub fn read_msg(&mut self, s: &mut String) -> Result<usize, DogStatsDReplayReaderError> {
         if let Some(line) = self.current_messages.pop_front() {
             s.insert_str(0, &line);
+            self.analytics.total_messages += 1;
             return Ok(1);
         }
 
         match self.replay_msg_reader.read_msg() {
             Ok(Some(msg)) => {
+                let timestamp = match self.replay_msg_reader.version {
+                    crate::replay::CaptureFileVersion::V3 => {
+                        Duration::from_nanos(msg.timestamp as u64)
+                    },
+                    crate::replay::CaptureFileVersion::V2 => {
+                        Duration::from_secs(msg.timestamp as u64)
+                    },
+                    _ => {
+                        panic!("Unexpected version in DogStatsDReplayReader::read_msg");
+                    }
+                };
+                if self.analytics.earliest_timestamp.is_zero() {
+                    self.analytics.earliest_timestamp = timestamp;
+                } else {
+                    self.analytics.latest_timestamp = timestamp;
+                }
+                self.analytics.total_packets += 1;
+                self.analytics.total_bytes += msg.payload.len() as u64;
                 match std::str::from_utf8(&msg.payload) {
                     Ok(v) => {
                         if v.is_empty() {
@@ -65,6 +88,7 @@ impl<'a> DogStatsDReplayReader<'a>
             Ok(reader) => Ok(DogStatsDReplayReader {
                 replay_msg_reader: reader,
                 current_messages: VecDeque::new(),
+                analytics: dogstatsdreader::Analytics::new(),
             }),
             Err(e) => match e {
                 ReplayReaderError::NotAReplayFile => {

--- a/src/pcapdogstatsdreader.rs
+++ b/src/pcapdogstatsdreader.rs
@@ -27,7 +27,7 @@ impl<'a> PcapDogStatsDReader<'a>
             Ok(reader) => Ok(PcapDogStatsDReader {
                 pcap_reader: reader,
                 current_messages: VecDeque::new(),
-                analytics: dogstatsdreader::Analytics::new(),
+                analytics: dogstatsdreader::Analytics::new(dogstatsdreader::Transport::Udp),
             }),
             Err(e) => Err(PcapDogStatsDReaderError::PcapReader(e)),
         }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -17,12 +17,19 @@ pub mod dogstatsd {
     }
 }
 
+pub enum CaptureFileVersion {
+    V1, // unsupported
+    V2, // unsupported, first version containing tagger state
+    V3, // first version with nanosecond timestamps
+}
+
 // TODO currently missing ability to read tagger state from replay file
 // If this is desired, the length can be found as the last 4 bytes of the replay file
 // Only present in version 2 or greater
 pub struct ReplayReader<'a> {
     reader: Box<dyn std::io::BufRead + 'a>,
     read_all_unixdogstatsdmsg: bool,
+    pub version: CaptureFileVersion,
     _buf: BytesMut,
 }
 
@@ -128,6 +135,7 @@ impl<'a> ReplayReader<'a> {
         Ok(Self {
             reader: byte_reader,
             read_all_unixdogstatsdmsg: false,
+            version: CaptureFileVersion::V3,
             _buf: BytesMut::with_capacity(MAX_MSG_SIZE),
         })
     }


### PR DESCRIPTION
A given pcap or uds-capture file contains enough metadata (and data) to emit a lading dogstatsd configuration that should roughly approximate the data contained within.

This PR adds this functionality to `dsd-analyze` and emits it by default, along with a new "Reader Stats" section that shows transport-level stats.

Current issues remaining:
- seed is hard-coded
